### PR TITLE
fix: use bt_ignore for terminals

### DIFF
--- a/vim/.config/nvim/lua/kirk/plugins/ui/statuscol.lua
+++ b/vim/.config/nvim/lua/kirk/plugins/ui/statuscol.lua
@@ -12,6 +12,7 @@ return {
     require("statuscol").setup({
       setopt = true,
       relculright = true,
+      bt_ignore = { "terminal" },
       ft_ignore = {
         "NeogitStatus",
         "NvimTree",
@@ -25,7 +26,6 @@ return {
         "scratch",
         "startify",
         "term",
-        "terminal",
         "toggleterm",
         "trouble",
       },


### PR DESCRIPTION
It's your dotfiles and it's none of my business, but it's got to be bt_ignore for buffer with 'terminal filetype